### PR TITLE
Add Electron Markdown editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # Markdown-Editor-v2
-Rebuild of Markdown Editor
+
+This project provides a simple Electron based Markdown editor with block based editing. Markdown and inline LaTeX expressions of the form `$ax^2$` are supported via **markdown-it** and **katex**.
+
+## Features
+- Each press of `Enter` finalises the current block and creates a new one.
+- Blocks can contain any Markdown including tables, headers, block quotes and code blocks.
+- Pages are rendered in A4 format and new pages are automatically added when needed.
+- A custom caret is displayed with a short easing animation when moving between characters.
+
+## Development
+To run the editor you will need Node.js installed. Install the dependencies and start Electron:
+
+```bash
+npm install
+npm start
+```
+
+If dependency installation fails due to network restrictions, download the listed packages manually and place them in `node_modules`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "markdown-editor-v2",
+  "version": "1.0.0",
+  "description": "Rebuild of Markdown Editor",
+  "main": "src/main.js",
+  "scripts": {
+    "start": "electron .",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "electron": "27.1.2",
+    "markdown-it": "^14.0.0",
+    "markdown-it-katex": "^3.0.1",
+    "katex": "^0.16.9"
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Markdown Editor</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
+  <style>
+    body {
+      margin: 0;
+      background: #ddd;
+      display: flex;
+      justify-content: center;
+      font-family: sans-serif;
+      height: 100vh;
+      overflow-y: scroll;
+    }
+    #pages {
+      margin: 20px auto;
+    }
+    .page {
+      width: 210mm;
+      min-height: 297mm;
+      box-shadow: 0 0 10px rgba(0,0,0,0.3);
+      background: white;
+      margin: 10mm auto;
+      padding: 20mm;
+    }
+    .block {
+      outline: none;
+      padding: 2px 4px;
+      margin: 4px 0;
+      min-height: 1em;
+    }
+    .block.edit {
+      caret-color: transparent; /* hide default caret */
+    }
+    #custom-caret {
+      position: absolute;
+      width: 2px;
+      background: black;
+      pointer-events: none;
+      transition: top 0.1s ease-out, left 0.1s ease-out;
+    }
+  </style>
+</head>
+<body>
+  <div id="pages"></div>
+  <div id="custom-caret"></div>
+  <script src="https://cdn.jsdelivr.net/npm/markdown-it@14/dist/markdown-it.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/markdown-it-katex@3/dist/markdown-it-katex.min.js"></script>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,27 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1000,
+    height: 800,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    }
+  });
+
+  win.loadFile(path.join(__dirname, 'index.html'));
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,0 +1,92 @@
+const pagesContainer = document.getElementById('pages');
+const caret = document.getElementById('custom-caret');
+const md = window.markdownit({html: true}).use(window.markdownitKatex);
+
+let currentPage = null;
+
+function createPage() {
+  const page = document.createElement('div');
+  page.className = 'page';
+  pagesContainer.appendChild(page);
+  currentPage = page;
+  return page;
+}
+
+function createBlock(page) {
+  const block = document.createElement('div');
+  block.className = 'block edit';
+  block.contentEditable = true;
+  block.dataset.raw = '';
+  block.addEventListener('keydown', onKeyDown);
+  block.addEventListener('input', updateCaret);
+  block.addEventListener('click', updateCaret);
+  page.appendChild(block);
+  block.focus();
+  updateCaret();
+  return block;
+}
+
+function finalizeBlock(block) {
+  block.dataset.raw = block.innerText;
+  block.innerHTML = md.render(block.dataset.raw);
+  block.classList.remove('edit');
+  block.contentEditable = false;
+  block.removeEventListener('input', updateCaret);
+  block.removeEventListener('click', updateCaret);
+}
+
+function editBlock(block) {
+  block.innerText = block.dataset.raw;
+  block.classList.add('edit');
+  block.contentEditable = true;
+  block.addEventListener('input', updateCaret);
+  block.addEventListener('click', updateCaret);
+  block.focus();
+  updateCaret();
+}
+
+function onKeyDown(e) {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    const block = e.target;
+    finalizeBlock(block);
+    ensureNewPage(block);
+    const newBlock = createBlock(currentPage);
+    scrollIntoViewSmooth(newBlock);
+  }
+}
+
+function ensureNewPage(block) {
+  const rect = block.getBoundingClientRect();
+  const pageRect = currentPage.getBoundingClientRect();
+  if (rect.bottom - pageRect.top > pageRect.height - 40) {
+    currentPage = createPage();
+  }
+}
+
+function scrollIntoViewSmooth(el) {
+  el.scrollIntoView({behavior: 'smooth', block: 'center'});
+}
+
+function updateCaret() {
+  const sel = window.getSelection();
+  if (!sel.rangeCount) return;
+  const range = sel.getRangeAt(0).cloneRange();
+  range.collapse(true);
+  const rects = range.getClientRects();
+  if (!rects.length) return;
+  const rect = rects[0];
+  caret.style.top = rect.top + 'px';
+  caret.style.left = rect.left + 'px';
+  caret.style.height = rect.height + 'px';
+}
+
+document.addEventListener('click', e => {
+  if (e.target.classList.contains('block') && !e.target.classList.contains('edit')) {
+    editBlock(e.target);
+  }
+});
+
+// initialize
+createPage();
+createBlock(currentPage);


### PR DESCRIPTION
## Summary
- initialize npm package and configure Electron entry
- add HTML page in A4 format
- implement block-based editing with Markdown-It and KaTeX
- add custom caret animation and auto-page creation
- document usage in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684173d718ec832eb89149e72e8b67e6